### PR TITLE
Add claims history

### DIFF
--- a/abis/redeemer.json
+++ b/abis/redeemer.json
@@ -1,0 +1,199 @@
+[
+  {
+    "inputs": [
+      { "internalType": "contract IERC20", "name": "_oopsieDAI", "type": "address" },
+      { "internalType": "address", "name": "_operator", "type": "address" },
+      { "internalType": "address", "name": "_admin", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "week", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      { "indexed": true, "internalType": "bytes32", "name": "newAdminRole", "type": "bytes32" }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "OPERATOR_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "week", "type": "uint256" },
+      { "internalType": "bytes32", "name": "root", "type": "bytes32" },
+      { "internalType": "uint256", "name": "totalWeekAmount", "type": "uint256" }
+    ],
+    "name": "addRoot",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32[]", "name": "proof", "type": "bytes32[]" },
+      { "internalType": "uint256", "name": "week", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "canClaim",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256[]", "name": "_weeks", "type": "uint256[]" },
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" },
+      { "internalType": "bytes32[][]", "name": "proofs", "type": "bytes32[][]" }
+    ],
+    "name": "claimMultiple",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deploymentWeek",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "amount", "type": "uint256" }],
+    "name": "emergencyWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentWeek",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "week", "type": "uint256" }],
+    "name": "getRoot",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oopsieDAI",
+    "outputs": [{ "internalType": "contract IERC20", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes4", "name": "interfaceId", "type": "bytes4" }],
+    "name": "supportsInterface",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "weeklyRoots",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/borrow/migrations/027-redeemer.sql
+++ b/src/borrow/migrations/027-redeemer.sql
@@ -1,0 +1,24 @@
+CREATE SCHEMA redeemer;
+
+CREATE TABLE redeemer.claim (
+    id         serial primary key,
+    "user"     character varying(66) not null,
+    week       decimal(78,0) not null,
+    amount     decimal(78,0) not null,
+    redeemer   character varying(66) not null,
+
+    log_index  integer not null,
+    tx_id      integer not null REFERENCES vulcan2x.transaction(id) ON DELETE CASCADE,
+    block_id   integer not null REFERENCES vulcan2x.block(id) ON DELETE CASCADE,
+    unique (tx_id, log_index)
+);
+
+CREATE INDEX claims ON redeemer.claim("user");
+
+CREATE VIEW api.claims AS
+    SELECT c.week, c.user, c.amount / 10^18 as amount, c.redeemer, t.hash as tx_hash, b.timestamp
+    FROM redeemer.claim c
+    LEFT JOIN vulcan2x.block b ON c.block_id = b.id
+    LEFT JOIN vulcan2x.transaction t ON c.tx_id = t.id
+    ORDER BY b.timestamp desc;
+    

--- a/src/borrow/migrations/027-redeemer.sql
+++ b/src/borrow/migrations/027-redeemer.sql
@@ -16,7 +16,7 @@ CREATE TABLE redeemer.claim (
 CREATE INDEX claims ON redeemer.claim("user");
 
 CREATE VIEW api.claims AS
-    SELECT c.week, c.user, c.amount / 10^18 as amount, c.redeemer, t.hash as tx_hash, b.timestamp
+    SELECT c.week, c.user as address, c.amount / 10^18 as amount, c.redeemer, t.hash as tx_hash, b.timestamp
     FROM redeemer.claim c
     LEFT JOIN vulcan2x.block b ON c.block_id = b.id
     LEFT JOIN vulcan2x.transaction t ON c.tx_id = t.id

--- a/src/borrow/transformers/referralRedeemer.ts
+++ b/src/borrow/transformers/referralRedeemer.ts
@@ -1,0 +1,66 @@
+import { flatten } from 'lodash';
+import { Dictionary } from 'ts-essentials';
+
+import { handleEvents, FullEventInfo } from '@oasisdex/spock-utils/dist/transformers/common';
+import {
+  getExtractorName,
+  PersistedLog,
+  SimpleProcessorDefinition,
+} from '@oasisdex/spock-utils/dist/extractors/rawEventDataExtractor';
+import { BlockTransformer } from '@oasisdex/spock-etl/dist/processors/types';
+import { LocalServices } from '@oasisdex/spock-etl/dist/services/types';
+import { normalizeAddressDefinition } from '../../utils';
+
+const redeemerAbi = require('../../../abis/redeemer.json');
+
+async function handleClaim(
+  params: Dictionary<any>,
+  log: PersistedLog,
+  services: LocalServices,
+): Promise<void> {
+  const values = {
+    user: params.user.toLowerCase(),
+    week: params.week.toString(),
+    amount: params.amount.toString(),
+    redeemer: log.address.toLocaleLowerCase(), 
+
+    log_index: log.log_index,
+    tx_id: log.tx_id,
+    block_id: log.block_id,
+  };
+
+  await services.tx.none(
+    `INSERT INTO redeemer.claim(
+          "user", week, amount, redeemer,
+          log_index, tx_id, block_id
+        ) VALUES (
+          \${user}, \${week}, \${amount}, \${redeemer},
+          \${log_index}, \${tx_id}, \${block_id}
+        );`,
+    values,
+  );
+}
+
+const redeemerHandlers = {
+  async Claimed(services: LocalServices, { event, log }: FullEventInfo): Promise<void> {
+    await handleClaim(event.params, log, services);
+  },
+};
+
+export const getRedeemerTransformerName = (address: string) => `redeemerTransformer-${address}`;
+export const redeemerTransformer: (
+  addresses: (string | SimpleProcessorDefinition)[],
+) => BlockTransformer[] = addresses => {
+  return addresses.map(_deps => {
+    const deps = normalizeAddressDefinition(_deps);
+
+    return {
+      name: getRedeemerTransformerName(deps.address),
+      dependencies: [getExtractorName(deps.address)],
+      startingBlock: deps.startingBlock,
+      transform: async (services, logs) => {
+        await handleEvents(services, redeemerAbi, flatten(logs), redeemerHandlers);
+      },
+    };
+  });
+};

--- a/src/config.goerli.ts
+++ b/src/config.goerli.ts
@@ -48,6 +48,7 @@ import { getIlkForCdp } from './borrow/dependencies/getIlkForCdp';
 import { getLiquidationRatio } from './borrow/dependencies/getLiquidationRatio';
 import { exchangeTransformer } from './borrow/transformers/exchange';
 import { multiplyHistoryTransformer } from './borrow/transformers/multiplyHistoryTransformer';
+import { redeemerTransformer } from './borrow/transformers/referralRedeemer';
 
 const AutomationBotABI = require('../abis/automation-bot.json');
 
@@ -84,6 +85,17 @@ const cats = [
   {
     address: goerliAddresses.MCD_CAT,
     startingBlock: GOERLI_STARTING_BLOCKS.MCD_CAT,
+  },
+];
+
+const redeemer = [
+  {
+    address: '0x5C9141C77F9c04f171f62B6fdFf5E4462e9FD83A',
+    startingBlock: 6893402,
+  },
+  {
+    address: '0x0A0647e629A0825353B76dEeC232b29df960ac2d',
+    startingBlock: 6991463,
   },
 ];
 
@@ -195,6 +207,7 @@ export const config: UserProvidedSpockConfig = {
   extractors: [
     ...makeRawLogExtractors(cdpManagers),
     ...makeRawLogExtractors(cats),
+    ...makeRawLogExtractors(redeemer),
     ...makeRawLogExtractors(dogs),
     ...makeRawLogExtractors([vat]),
     ...makeRawLogExtractors([automationBot]),
@@ -244,6 +257,7 @@ export const config: UserProvidedSpockConfig = {
       exchangeAddress: [...exchange],
     }),
     eventEnhancerGasPrice(vat, cdpManagers),
+    ...redeemerTransformer(redeemer),
   ],
   migrations: {
     borrow: join(__dirname, './borrow/migrations'),


### PR DESCRIPTION
Adds history of claims (only on goerli now). To test use this env variables, genesis is set in the same block number as one claim so you do not have to wait until cache finds `Claim` event. 

```
VL_CHAIN_HOST=https://eth-goerli.alchemyapi.io/v2/JUQi8Hl2jNdFwUoEMZJZ_HsTvuH6myXx
VL_CHAIN_NAME=goerli

GENESIS=6936482
```