### PR TITLE
added command alias for basic buy

### DIFF
--- a/src/config.goerli.ts
+++ b/src/config.goerli.ts
@@ -159,6 +159,10 @@ const commandMapping = [
     command_address: '0x31285A87fB70a62b5AaA43199e53221c197E1e3f'.toLowerCase(),
     kind: 'stop-loss',
   },
+  {
+    command_address: '0x7c86781A95b7E55E6C2F7297Ae6773e1dbcEAb13'.toLowerCase(),
+    kind: 'basic-buy',
+  },
 ];
 
 const multiply = [


### PR DESCRIPTION
To test run dev.sh, then run `yarn start-etl` then `select * from automation_bot.command_alias ca `
expect basic buy with correct address 
![image](https://user-images.githubusercontent.com/6871923/175059152-c9d08e54-fe75-4e17-aa51-950f7e85b4ec.png)
