### PR TITLE
Update cache to support gas_fee and eth_price for automation events on mainnet

### DIFF
--- a/src/config.mainnet.ts
+++ b/src/config.mainnet.ts
@@ -50,6 +50,10 @@ import { automationBotTransformer } from './borrow/transformers/automationBotTra
 import { redeemerTransformer } from './borrow/transformers/referralRedeemer';
 import { lidoTransformer } from './borrow/transformers/lidoTransformer';
 import { aaveLendingPoolTransformer } from './borrow/transformers/aaveTransformer';
+import {
+  automationEventEnhancerGasPrice,
+  automationEventEnhancerTransformerEthPrice,
+} from './borrow/transformers/automationEventEnhancer';
 
 const mainnetAddresses = require('./addresses/mainnet.json');
 
@@ -292,6 +296,8 @@ export const config: UserProvidedSpockConfig = {
       exchangeAddress: [...exchange],
     }),
     eventEnhancerGasPrice(vat, cdpManagers),
+    automationEventEnhancerGasPrice(automationBot),
+    automationEventEnhancerTransformerEthPrice(automationBot, oraclesTransformers),
     ...redeemerTransformer(redeemer),
     ...lidoTransformer(lido),
     ...aaveLendingPoolTransformer(aaveLendingPool),


### PR DESCRIPTION
1. deploy aggregator and validator to mainnet
2. merge `https://github.com/OasisDEX/oasis-borrow-cache/pull/141`
3. merge
4. test