### PR TITLE
[Cache] Add support for AutoTakeProfit

### DIFF
--- a/src/config.goerli.ts
+++ b/src/config.goerli.ts
@@ -213,6 +213,10 @@ const commandMapping = [
     command_address: '0x2eCC5086CE10194175607d0D082fC27c3416693d',
     kind: 'basic-sell',
   },
+  {
+    command_address: '0x02B7391cdd0c8A75ecFC278d387e3DCC3d796340',
+    kind: 'auto-take-profit',
+  },
 ].map(({ command_address, kind }) => ({ command_address: command_address.toLowerCase(), kind }));
 
 const multiply = [


### PR DESCRIPTION
[Add support for AutoTakeProfit](https://app.shortcut.com/oazo-apps/story/5561/cache-add-support-for-autotakeprofit)