### PR TITLE
TECH-1124 - Upgrading Node.js 12 (End-of-Life) Github Actions to Node.js 16

### DIFF
--- a/.github/workflows/aws-prod.yml
+++ b/.github/workflows/aws-prod.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/aws-staging.yml
+++ b/.github/workflows/aws-staging.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -27,10 +27,10 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Cache YARN dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
TECH-1124 - Node.js 12 Github Actions are deprecated as Node.js 12 reached End-of-Life on April 2022. This PR upgrades them to Node.js 16